### PR TITLE
Add test against a dev node in github action workflow (#8)

### DIFF
--- a/.github/workflows/substrate-rpc-tester.yml
+++ b/.github/workflows/substrate-rpc-tester.yml
@@ -11,18 +11,23 @@ jobs:
       matrix:
         deno: ["1.41"]
     runs-on: ubuntu-latest
+    services:
+      cess-chain:
+        image: hkwtf/cess-devnode:testnet
+        ports:
+          - 9944:9944
     steps:
       - uses: actions/checkout@v3
       - uses: denoland/setup-deno@v1
         with:
           deno-version: ${{ matrix.deno }}
 
-      - name: Validate application
-        run: |
-          cd substrate-rpc-tester
-          deno task validate
-
       - name: Build application
         run: |
           cd substrate-rpc-tester
           deno task compile
+
+      - name: Validate and Run Tests
+        run: |
+          cd substrate-rpc-tester
+          RPC_ENDPOINT="ws://127.0.0.1:9944" deno task validate

--- a/substrate-rpc-tester/deno.jsonc
+++ b/substrate-rpc-tester/deno.jsonc
@@ -12,9 +12,9 @@
     "start": "deno run --allow-read --allow-net --allow-env --check src/main.ts",
     "compile": "deno compile --check --allow-read --allow-net --allow-env --output dist/substrate-rpc-tester src/main.ts",
     "test": "deno test --allow-read --allow-net --allow-env --fail-fast",
-    "test:remote": "RPC_ENDPOINT=\"ws://127.0.0.1:9944\" deno task test",
-    "validate": "deno check src/main.ts && deno fmt --check && deno lint && deno task test",
-    "validate:remote": "RPC_ENDPOINT=\"ws://127.0.0.1:9944\" deno task validate"
+    "test:localhost-node": "RPC_ENDPOINT=\"ws://127.0.0.1:9944\" deno task test",
+    "validate": "deno check src/**/*.ts && deno fmt --check && deno lint && deno task test",
+    "validate:localhost-node": "RPC_ENDPOINT=\"ws://127.0.0.1:9944\" deno task validate"
   },
   "compilerOptions": {
     "strict": true,

--- a/substrate-rpc-tester/docker/cess-devnode.dockerfile
+++ b/substrate-rpc-tester/docker/cess-devnode.dockerfile
@@ -1,0 +1,7 @@
+# docker push to:
+#   https://hub.docker.com/r/hkwtf/cess-devnode/tags
+FROM cesslab/cess-chain:testnet
+EXPOSE 9944
+RUN echo "$PWD/cess-node --dev --rpc-methods unsafe --rpc-external" > /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/usr/bin/bash", "-c", "/entrypoint.sh"]

--- a/substrate-rpc-tester/src/test/integration_test.ts
+++ b/substrate-rpc-tester/src/test/integration_test.ts
@@ -10,10 +10,10 @@ import type { AppConfig } from "../types.ts";
 const SCRIPT_PATH = fromFileUrl(import.meta.resolve("./test_cfg.jsonc"));
 
 Deno.test({
-  name: "Running localhost.jsonc script once should work",
+  name: "Running test_cfg.jsonc script once should work",
   ignore: !rpcEndPoint || rpcEndPoint.length === 0,
   async fn(t) {
-    await t.step("Running localhost.jsonc against cess-node should work", async () => {
+    await t.step("Running test_cfg.jsonc against cess-node should work", async () => {
       console.log(SCRIPT_PATH);
       const configTxt = await Deno.readTextFile(SCRIPT_PATH);
       const config = jsonc.parse(configTxt);
@@ -25,6 +25,8 @@ Deno.test({
 
       const appConfig = config as unknown as AppConfig;
       appConfig.connections = 1;
+      // Replace the config RPC endpoint with the one from env
+      appConfig.endPoint = rpcEndPoint as string;
 
       const substrateRpcTester = new SubstrateRpcTester(appConfig, { verbose: true });
       await substrateRpcTester.initialize();


### PR DESCRIPTION
Running test against a `cess-node --dev` in Github CI workflow